### PR TITLE
pkg/processing: Let's fix the data race

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,9 +278,6 @@ the [ScyllaDB][] processor backend:
 
 ```golang
 func (p *scyllaProcessor) Process(ctx context.Context, msg Scan) error {
-	if err := p.getSession(); err != nil {
-		return err
-	}
 	// WithTimestamp gurantees the latest scanned entries in the
 	// ScyllaDB datastore.
 	//

--- a/cmd/processor/main.go
+++ b/cmd/processor/main.go
@@ -35,7 +35,7 @@ func main() {
 	}
 	b, err := NewBuilder(ctx, cfg)
 	if err != nil {
-		log.Fatalf("Can't create the Pub/Sub client: %v", err)
+		log.Fatalf("Can't create the processor builder: %v", err)
 	}
 
 	// Spawns the processor goroutine(s).
@@ -78,7 +78,10 @@ func NewBuilder(
 	if err != nil {
 		return nil, err
 	}
-	processor := processing.NewProcessor(cfg)
+	processor, err := processing.NewProcessor(cfg)
+	if err != nil {
+		return nil, err
+	}
 	return &builder{
 		client:    client,
 		processor: processor,

--- a/pkg/processing/processor.go
+++ b/pkg/processing/processor.go
@@ -9,12 +9,12 @@ import (
 //
 // Please take a look at ProcessorConfig type how to configure
 // Processor.
-func NewProcessor(cfg ProcessorConfig) Processor {
+func NewProcessor(cfg ProcessorConfig) (Processor, error) {
 	switch cfg.BackendType() {
 	case BackendScylla:
 		return newScyllaProcessor(cfg)
 	default:
-		return &logProcessor{}
+		return &logProcessor{}, nil
 	}
 }
 


### PR DESCRIPTION
There is a data race in ScyllaDB processor backend, as it writes the ScyllaDB session variable,
which is also read by other goroutines.  Instead of lazily create a session, the fix create a session
during the creation phase.  Since the gocql.Session is concurrency safe, this makes
the ScyllaDB concurrency safe without introducing the sync.Mutex based serialization.