### PR TITLE
pkg/processing: Lazy Scylla session initialization with sync.Once

### DIFF
--- a/cmd/processor/main.go
+++ b/cmd/processor/main.go
@@ -78,10 +78,7 @@ func NewBuilder(
 	if err != nil {
 		return nil, err
 	}
-	processor, err := processing.NewProcessor(cfg)
-	if err != nil {
-		return nil, err
-	}
+	processor := processing.NewProcessor(cfg)
 	return &builder{
 		client:    client,
 		processor: processor,

--- a/pkg/processing/processor.go
+++ b/pkg/processing/processor.go
@@ -2,6 +2,7 @@ package processing
 
 import (
 	"context"
+	"errors"
 	"log"
 )
 
@@ -9,12 +10,12 @@ import (
 //
 // Please take a look at ProcessorConfig type how to configure
 // Processor.
-func NewProcessor(cfg ProcessorConfig) (Processor, error) {
+func NewProcessor(cfg ProcessorConfig) Processor {
 	switch cfg.BackendType() {
 	case BackendScylla:
 		return newScyllaProcessor(cfg)
 	default:
-		return &logProcessor{}, nil
+		return &logProcessor{}
 	}
 }
 
@@ -25,4 +26,11 @@ func logger(ctx context.Context) *log.Logger {
 	} else {
 		return log.Default()
 	}
+}
+
+// Utility function to wrap the processing backend error with the
+// generic ErrBackend error.
+func backendError(errs ...error) error {
+	errs = append(errs, ErrBackend)
+	return errors.Join(errs...)
 }

--- a/pkg/processing/types.go
+++ b/pkg/processing/types.go
@@ -35,6 +35,16 @@ var ErrScanDataType = errors.New("Invalid scan data type")
 // ErrScanDataEncoding indicates the wrong scan data encoding.
 var ErrScanDataEncoding = errors.New("Invalid scan data encoding")
 
+// ErrBackend indicates the general processor backend error.
+//
+// The detailed error could be passed by the actual processor backend
+// but the following code will capture all the backend related errors.
+//
+//	if err := ...; errors.Is(processing.ErrBackend) {
+//	   ...
+//	}
+var ErrBackend = errors.New("Processor Backend error")
+
 // Processor interface to represent the message processor.
 type Processor interface {
 	// Process processes the incoming Scan data.


### PR DESCRIPTION
Instead of the fat new function, let's implement the lazy session initialization with sync.Once.