### PR TITLE
pkg/processing: Fix the segv in Scylla session closure

### DIFF
--- a/pkg/processing/scylla.go
+++ b/pkg/processing/scylla.go
@@ -54,7 +54,9 @@ func (p *scyllaProcessor) Process(ctx context.Context, msg Scan) error {
 func (p *scyllaProcessor) Close(ctx context.Context) {
 	// We don't need the memory serialization here, as
 	// gocql.Session.Close() is concurrency safe.
-	p.session.Close()
+	if !p.session.Closed() {
+		p.session.Close()
+	}
 }
 
 // For lazy initialization of Scylla session by aquireSession().


### PR DESCRIPTION
We can't call the Session.Close() multiple times.

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x1050d029c]

goroutine 1 [running]:
github.com/gocql/gocql.(*Session).Close(0x0)
        /Users/keith/pkg/mod/github.com/scylladb/gocql@v1.14.4/session.go:519 +0x1c
github.com/censys/scan-takehome/pkg/processing.(*scyllaProcessor).Close(0x1053e4a50?, {0x105942f20?, 0x2540be400?})
        /Users/keith/git/mini-scan-takehome/pkg/processing/scylla.go:57 +0x20
main.(*builder).close(...)
        /Users/keith/git/mini-scan-takehome/cmd/processor/main.go:123
main.main()
        /Users/keith/git/mini-scan-takehome/cmd/processor/main.go:59 +0x594
exit status 2